### PR TITLE
fixed README & compose & workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       run: | 
         python -m pip install --upgrade pip 
         pip install flake8 pep8-naming flake8-broken-line flake8-return flake8-isort
-        pip install -r egrul/requirements.txt
+        pip install -r egrul/requirements_tests.txt
     - name: Testing with flake8
       run: |
         # запуск проверки проекта по flake8

--- a/.gitignore
+++ b/.gitignore
@@ -105,10 +105,10 @@ celerybeat.pid
 *.env
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
-venv.bak/
+venv*.bak/
 
 # Spyder project settings
 .spyderproject
@@ -137,3 +137,4 @@ infra/.env
 
 !.env.example
 
+egrul/static

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ nano infra/.env
 
 ```bash
 cd infra/
-docker-compose up --build --d
-docker-compose exec web python3 manage.py migrate
-docker-compose exec web python3 manage.py collectstatic
+docker compose -p egrul up --build --d
+docker compose -p egrul exec web python3 manage.py migrate
+docker compose -p egrul exec web python3 manage.py collectstatic
 ```
 
 Перейти по [адресу](http://localhost:28961/api/) и убедиться в работоспособности сервиса.
@@ -58,7 +58,7 @@ docker-compose exec web python3 manage.py collectstatic
 Для этого используется команда `fill_egrul`.
 
 ```bash
-docker-compose exec web python3 manage.py fill_egrul egrul_data/<path_to_dir_with_xml> -n <proc_num> [--update]
+docker compose -p egrul exec web python3 manage.py fill_egrul egrul_data/<path_to_dir_with_xml> -n <proc_num> [--update]
 ```
 
 *egrul_data/<path_to_dir_with_xml>* - путь до директории с файлами XML; в текущем
@@ -72,7 +72,7 @@ egrul_data монтируется в /tmp/.
 Для демонстрации работы сервиса предусмотрена команда, которая создаст *N* вымышленных организаций
 
 ```bash
-docker-compose exec web python3 manage.py fill_test_data <N>
+docker compose -p egrul exec web python3 manage.py fill_test_data <N>
 ```
 
 ### Особенности реализации полнотекстового поиска

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   db:
     build:
@@ -20,6 +19,7 @@ services:
     build:
       context: ../egrul
       dockerfile: Dockerfile
+      network: host
     restart: always
     volumes:
       - static_value:/app/static/


### PR DESCRIPTION
1. воркфлоу - зависимости для тестов
2. gitignore - для всех папок, начинающихся с venv и спрятать статику
3. README.md - в описание добавлен флажок -p, чтобы названия контейнеров были привязаны к названию проекта
4. compose.yaml - питон пакеты не грузились без параметра network